### PR TITLE
Update README to use highwire tags in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ This file should contain contents similar to this:
 
 ```
 ---
-:static:
-  Institution: Emory & University
-:attributes:
-  Title: title
-  Author: creator
-  Abstract: abstract
-  Type: submitting_type
-  Date: degree_awarded
+static:
+  citation_dissertation_institution: Your University
+attributes:
+  citation_title: title
+  citation_author: creator
+  citation_date: publication_date
+  citation_keywords: keywords
+  citation_pdf_url: permanent_url
 ```
 
 The 'static' section will be written directly into the meta tags as is, attributes will be sent as method calls to the current curation


### PR DESCRIPTION
Based on analysis conducted internally and a scan of current tagging
practices across DSpace, BePress, Eprints, and other repositories
it appears that the "highwire press" tag set, though not formally
documented, is the most broadly used system for &lt;meta&gt; tagging
to support inclusion in Google Scholar indexing and searches.

For additional reference we found the following two papers helpful
* https://scholarworks.montana.edu/xmlui/handle/1/3193 - p. 36
* https://www.monperrus.net/martin/accurate+bibliographic+metadata+and+google+scholar